### PR TITLE
docs(readme): add Author section with link to maintainer profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,3 +64,7 @@ Contributions are welcome! Please see [CONTRIBUTING.md](./CONTRIBUTING.md) for c
 ## License
 
 This project is licensed under the [MIT License](./LICENSE).
+
+## Author
+
+- Rafiul Islam – https://github.com/RafiulM


### PR DESCRIPTION
Adds an Author section to README including the maintainer’s name and GitHub profile link. Matches existing Markdown style and placement near License.