### PR TITLE
docs: add author information to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,10 @@ The default endpoint works with the standard Agno Playground setup described in 
 
 Contributions are welcome! Please see [CONTRIBUTING.md](./CONTRIBUTING.md) for contribution guidelines.
 
+## Author
+
+- **Rafiul Islam** - [@RafiulM](https://github.com/RafiulM)
+
 ## License
 
 This project is licensed under the [MIT License](./LICENSE).


### PR DESCRIPTION
### Summary

Adds an Author section to README.md with author name and GitHub profile link for proper attribution.