### PR TITLE
docs: add Author section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,3 +64,8 @@ Contributions are welcome! Please see [CONTRIBUTING.md](./CONTRIBUTING.md) for c
 ## License
 
 This project is licensed under the [MIT License](./LICENSE).
+
+## Author
+
+- Name: Rafiul Islam
+- GitHub: [@RafiulM](https://github.com/RafiulM)


### PR DESCRIPTION
This PR adds an 'Author' section to the README, including the author's name and GitHub profile, following existing Markdown conventions.