### PR TITLE
docs: add Author section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,3 +64,7 @@ Contributions are welcome! Please see [CONTRIBUTING.md](./CONTRIBUTING.md) for c
 ## License
 
 This project is licensed under the [MIT License](./LICENSE).
+
+## Author
+
+- Rafiul Islam — [@RafiulM](https://github.com/RafiulM)


### PR DESCRIPTION
Adds a clearly labeled Author section to README with maintainer name and GitHub link. Aligns with Markdown style and sits after License section.